### PR TITLE
fix: Update isDenom to detect "ncheq".

### DIFF
--- a/src/is.ts
+++ b/src/is.ts
@@ -9,8 +9,12 @@ export const isDenomTerra = (string = "") =>
 
 export const isDenomIBC = (string = "") => string.startsWith("ibc/")
 
+// The cheqd blockchain uses the "n" prefix for the minimal 
+// denomination instead of the standard "u" prefix.
+const isDenomCheq = (string = "") => 'ncheq' === string
+
 export const isDenomTerraNative = (string = "") =>
   isDenomLuna(string) || isDenomTerra(string)
 
 export const isDenom = (string = "") =>
-  string.startsWith("u") || isDenomIBC(string)
+  string.startsWith("u") || isDenomCheq(string) || isDenomIBC(string)

--- a/test/is.test.ts
+++ b/test/is.test.ts
@@ -8,4 +8,5 @@ test("isDenomTerra", () => {
 test("isDenom", () => {
   expect(isDenom("uusd")).toBeTruthy()
   expect(isDenom("uluna")).toBeTruthy()
+  expect(isDenom("ncheq")).toBeTruthy()
 })


### PR DESCRIPTION
`isDenom` is unable to detect `ncheq`, which is the native token for the cheqd blockchain. For now I've decided to add an explicit check for `ncheq` which should work until we run into another chain that doesn't use the `u` prefix or another edge case.